### PR TITLE
Suporte a comentários e correção de typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# [fsavio.dev](https://fsavio.dev)
+
+Repositório do meu blog pessoal.
+
+## Tecnologias:
+
+- Linguagem: [Go](https://golang.org/)
+- Static Site Generator: [Hugo](https://gohugo.io/)
+- Hugo Theme: [PaperMod](https://themes.gohugo.io/themes/hugo-papermod/) (modificado)
+- Syntax highlighting Theme: [Dracula](https://xyproto.github.io/splash/docs/longer/dracula.html) 
+([Docs](https://gohugo.io/content-management/syntax-highlighting/#generate-syntax-highlighter-css))
+- Comentários: [Utterances](https://utteranc.es/)
+- Hospedagem: [Netlify](https://www.netlify.com/)
+- Pesquisa: [Fuse.js](https://fusejs.io/)
+- Analytics: [Woopra](https://www.woopra.com/)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Netlify Status](https://api.netlify.com/api/v1/badges/8fad91db-5199-4007-ab1d-c49518e7df93/deploy-status)](https://app.netlify.com/sites/fsavio/deploys)
+
 # [fsavio.dev](https://fsavio.dev)
 
 Repositório do meu blog pessoal.

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -18,7 +18,7 @@ ShowCodeCopyButtons = false
 disableSpecial1stPost = true
 disableScrollToTop = false
 
-comments = false
+comments = true
 hidemeta = false
 hideSummary = false
 showtoc = true

--- a/config/development/params.toml
+++ b/config/development/params.toml
@@ -1,0 +1,1 @@
+comments = false

--- a/content/posts/otimizacao-de-codigo-usando-formula-de-juro-composto/index.md
+++ b/content/posts/otimizacao-de-codigo-usando-formula-de-juro-composto/index.md
@@ -6,7 +6,7 @@ cover:
     alt: "Imagem de capa de um table com gráficos."
     relative: true
 description: "Resolução de um problema proposto na plataforma repl.it que usa a fórmula de juros compostos ao invés de usar loop."
-summary: "Neste artigo mosto como foi otimizado um algoritmo que usava loop para efetuar um cálculo com performance linear, para um algoritmo com performance constante usando a fórmula do juro composto."
+summary: "Neste artigo mostro como foi otimizado um algoritmo que usava loop para efetuar um cálculo com performance linear, para um algoritmo com performance constante usando a fórmula do juro composto."
 categorias:
   - Programação
 tags:

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,0 +1,8 @@
+<script src="https://utteranc.es/client.js"
+        repo="fernandosavio/fsavio.dev"
+        issue-term="pathname"
+        label="comment"
+        theme="photon-dark"
+        crossorigin="anonymous"
+        async>
+</script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,7 @@ command = "hugo --gc --minify"
 [context.production.environment]
 HUGO_ENV = "production"
 HUGO_VERSION = "0.83.1"
+
+[context.deploy-preview.environment]
+HUGO_ENV = "production"
+HUGO_VERSION = "0.83.1"


### PR DESCRIPTION
Adicionado suporte a comentários no blog usando [utteranc.es](https://utteranc.es/) e correção de _typo_ no sumário do único post do blog :|